### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
 		}
 	],
 	"require": {
-		"php": ">=5.4.0"
+		"php": ">=5.4.0",
+		"cakephp/cakephp": "~3.0"
 	},
 	"require-dev": {
-		"cakephp/cakephp": "3.0.*-dev",
 		"phpunit/phpunit": "4.1.*"
 	},
 	"autoload": {


### PR DESCRIPTION
Require CakePHP~3.0 instead of dev version (to match the final 3.0 released a few days ago);
Changed CakePHP from "require-dev" to "require" since CakePHP is needed to run this Plugin.