### PR TITLE
Null password

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /vendor
 /coverage
 /phpunit.xml
+/nbproject/private/

--- a/README.md
+++ b/README.md
@@ -112,5 +112,14 @@ if($this->request->data('remember_me')) {
 }
 ```
 
+If you use LDAP for authentication you don't want to store the password obviously.
+You can set the password to null when writing the cookie.
+``` php
+	$this->Cookie->write('CookieAuth', [
+		'username' => $this->request->data('username'),
+		'password' => null
+	]);
+```
+
 ## Contribute
 [Follow this guide to contribute](https://github.com/Xety/Cake3-CookieAuth/blob/master/CONTRIBUTING.md)

--- a/src/Auth/CookieAuthenticate.php
+++ b/src/Auth/CookieAuthenticate.php
@@ -45,7 +45,7 @@ class CookieAuthenticate extends BaseAuthenticate
         }
 
         extract($this->_config['fields']);
-        if (empty($cookies[$username]) || empty($cookies[$password])) {
+        if (empty($cookies[$username])) {
             return false;
         }
 

--- a/tests/Fixture/UsersFixture.php
+++ b/tests/Fixture/UsersFixture.php
@@ -37,6 +37,10 @@ class UsersFixture extends TestFixture
         [
             'username' => 'Larry',
             'password' => 'passlarry'
+        ],
+        [
+            'username' => 'Rubyan',
+            'password' => null
         ]
     ];
 }

--- a/tests/TestCase/Auth/CookieAuthenticateTest.php
+++ b/tests/TestCase/Auth/CookieAuthenticateTest.php
@@ -97,6 +97,22 @@ class CookieAuthenticateTest extends TestCase
         $result = $this->auth->authenticate($this->request, $this->response);
         $this->assertFalse($result);
     }
+    
+    /**
+     * test authenticateNullPassword
+     *
+     * @return void
+     */
+    public function testAuthenticateNullPassword()
+    {
+        $this->registry->Cookie->write(
+            'CookieAuth',
+            ['username' => 'Rubyan', 'password' => null]
+        );
+
+        $result = $this->auth->authenticate($this->request, $this->response);
+        $this->assertNotNull($result);
+    }
 
     /**
      * test authenticateFail


### PR DESCRIPTION
This enhancement allows authentication using an external provider such as LDAP, and still be able to log in using a cookie without storing the password.